### PR TITLE
add skill-review CI for skill.md PRs

### DIFF
--- a/.github/workflows/skill-apply-optimize.yml
+++ b/.github/workflows/skill-apply-optimize.yml
@@ -1,0 +1,19 @@
+name: Apply Skill Optimization
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  apply:
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/apply-optimize')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review-and-optimize@d81583861aaf29d1da7f10e6539efef4e27b0dd5
+        with:
+          mode: 'apply'

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,17 @@
+name: Skill Review & Optimize
+on:
+  pull_request:
+    paths: ['**/SKILL.md']
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review-and-optimize@d81583861aaf29d1da7f10e6539efef4e27b0dd5
+        with:
+          optimize: 'true'
+          tessl-token: ${{ secrets.TESSL_API_TOKEN }}


### PR DESCRIPTION
hey @ECNU-ICALK, glad you found #3 useful! adding two small workflow files that run the same evals I used for the improvements:

- `skill-review.yml` auto-posts a score on PRs touching skill.md files (read-only, `contents: read` + `pull-requests: write` for the comment - no signup, no tokens needed)
- `skill-apply-optimize.yml` lets you accept suggestions by commenting `/apply-optimize` (opt-in, needs a free token from tessl.io/account/api-keys as `TESSL_API_TOKEN` in repo secrets)

## how it fits with your existing CI

this repo doesn't have CI workflows yet - these two files would be the first, and they only trigger on skill.md changes. both action refs are SHA-pinned and you can inspect everything in `.github/workflows/` before approving runs.

this means you and your contributors get an instant quality signal + improvement suggestions before you review.